### PR TITLE
fix context tag name typo

### DIFF
--- a/client/src/contexts/InteractionsContext.jsx
+++ b/client/src/contexts/InteractionsContext.jsx
@@ -24,7 +24,7 @@ export const InteractionsContext ({ children }) => {
     logInteraction,
   };
 
-  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+  return <InteractionsContext.Provider value={value}>{children}</InteractionsContext.Provider>;
 }
 
 const useInteractions = () => {


### PR DESCRIPTION
` return <CartContext.Provider value={value}>{children}</CartContext.Provider>;`

should be

 return <InteractionsContext.Provider value={value}>{children}</InteractionsContext.Provider>;