### PR TITLE
create bare bones product card component

### DIFF
--- a/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.jsx
+++ b/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.jsx
@@ -1,17 +1,53 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import Card from 'react-bootstrap/Card';
 
-const ProductCard = () => {
-  // accepts a product object (w/ image, details, price etc)
-  // accepts an action button to display
+const placeholderImg = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-image_large.png?format=jpg&quality=90&v=1530129081';
 
-  // handles logic for hovering for price comparison
-  // handles some logic for clicking action button
-  // handles some logic for changing the page to display this product
+const ProductCard = (props) => {
+  /* ******************************************************************
+  // Keep track of which thumbnail image to display
+  const [productStyleIndex, setProductStyleIndex] = useState(0);
+
+  // Fetch more complete details for this product
+  useEffect(() => {
+    if (!props['styles']) {
+      // fetch product styles (/api/product/:productId/styles)
+    }
+  }, []);
+
+  const extractThumbnailLink = (props) => {
+    try {
+      const imageUrl = props['styles'][productStyleIndex].photos[0].thumbnail_url;
+      return imageUrl;
+    } catch {
+      return '';
+    }
+  }
+
+  const extractSalesPrice = (props) => {
+    try {
+      const imageUrl = props['styles'][productStyleIndex].sale_price;
+      return imageUrl;
+    } catch {
+      return '';
+    }
+  }
+  <Card.Img variant="top" src={extractThumbnailLink(props)placeholderImg} />
+  ****************************************************************** */
+
+  // 140.00 (integer) => "$140" (string)
+  const formattedPriceStr = '$' + (Number(props['default_price'])).toFixed(0).toLocaleString()
 
   return (
-    <div className="productCard">
-      <p>under construction</p>
-    </div>
+    <Card style={{ width: '18rem' }} className="productCard">
+      <Card.Img variant="top" src={placeholderImg} />
+      <Card.Body>
+        <Card.Subtitle>{props.category}</Card.Subtitle>
+        <Card.Title>{props.name}</Card.Title>
+        <Card.Subtitle>{formattedPriceStr}</Card.Subtitle>
+        {/* <ProductRating /> */}
+      </Card.Body>
+    </Card>
   );
 };
 

--- a/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.test.js
+++ b/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import ProductCard from './ProductCard.jsx';
+import sampleProduct from './sampleProduct';
+
+describe('ProductCard', () => {
+  let props;
+
+  // accepts an action button to display
+
+  // handles logic for hovering for price comparison
+  // handles some logic for clicking action button
+  // handles some logic for changing the page to display this product
+
+  beforeEach(() => {
+    // Refresh the props object before each test
+    props = Object.assign({}, sampleProduct);
+  });
+
+  test('renders ProductCard component', () => {
+    render(<ProductCard {...props} />);
+  });
+
+  test('renders product details from props', () => {
+    render(<ProductCard {...props} />);
+
+    expect(screen.getByText('Camo Onesie')).toBeTruthy();
+    expect(screen.getByText('Jackets')).toBeTruthy();
+    expect(screen.getByText('$140')).toBeTruthy();
+    expect(screen.getByRole('img')).toBeTruthy();
+  });
+});

--- a/client/src/Components/RelatedContainer/CardList/ProductCard/sampleProduct.js
+++ b/client/src/Components/RelatedContainer/CardList/ProductCard/sampleProduct.js
@@ -1,0 +1,91 @@
+const sampleProduct = {
+  "id": 42366,
+  "campus": "hr-lax",
+  "name": "Camo Onesie",
+  "slogan": "Blend in to your crowd",
+  "description": "The So Fatigues will wake you up and fit you in. This high energy camo will have you blending in to even the wildest surroundings.",
+  "category": "Jackets",
+  "default_price": "140.00",
+  "created_at": "2021-08-13T14:39:39.968Z",
+  "updated_at": "2021-08-13T14:39:39.968Z",
+  "styles": [
+    {
+      "style_id": 253626,
+      "name": "Black Lenses & Black Frame",
+      "original_price": "69.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": null,
+          "url": null
+        }
+      ],
+      "skus": {
+        "null": {
+          "quantity": null,
+          "size": null
+        }
+      }
+    },
+    {
+      "style_id": 253627,
+      "name": "Black Lenses & Gold Frame",
+      "original_price": "69.00",
+      "sale_price": null,
+      "default?": true,
+      "photos": [
+        {
+          "thumbnail_url": null,
+          "url": null
+        }
+      ],
+      "skus": {
+        "null": {
+          "quantity": null,
+          "size": null
+        }
+      }
+    },
+    {
+      "style_id": 253628,
+      "name": "Gold Lenses & Black Frame",
+      "original_price": "69.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": null,
+          "url": null
+        }
+      ],
+      "skus": {
+        "null": {
+          "quantity": null,
+          "size": null
+        }
+      }
+    },
+    {
+      "style_id": 253629,
+      "name": "Gold Lenses & Gold Frame",
+      "original_price": "69.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": null,
+          "url": null
+        }
+      ],
+      "skus": {
+        "null": {
+          "quantity": null,
+          "size": null
+        }
+      }
+    }
+  ]
+};
+
+export default sampleProduct;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "server/index.js",
   "scripts": {
-    "test": "jest --config ./jest.config.js",
-    "test:watch": "npm run test -- --watchAll",
+    "test": "jest --config ./jest.config.js --watchAll",
+    "test:watch": "npm run test",
     "build": "webpack -w",
     "start": "nodemon server/index.js",
     "postinstall": "pre-commit install",


### PR DESCRIPTION
Wrote tests for the ProductCard component => **[1.4.1] Related Product Cards**

> See comments for literal business requirements.


![Screen Shot 2021-09-13 at 10 18 12 AM](https://user-images.githubusercontent.com/60903378/133129514-8f1f5eeb-4bd1-49b0-87d7-f49eae9ac507.png)

### **Features involved:**
1.4.1.1.  Product Information
1.4.1.2.  Product Preview Images

## **Overview:**
Write an element to accept product details and render them in a `react-bootstrap/Card`

Created some tests for the ProductCard component. This will match the demo shown in the image above.
The test will pass down a product object (see `/ProductCard/sampleProduct.js`)
The ProductCart will use the react-bootstrap Card and render the props.

There are more functions to be used in the ProductCard. The original list of products from '/api/products/'
does not contain an object with ALL product details. For example, the thumbnail images are not included. Once the card renders, it will need to fetch more details from the API.
