### PR TITLE
add test coverage for related container

### DIFF
--- a/client/src/Components/RelatedContainer/OutfitProducts/OutfitProducts.jsx
+++ b/client/src/Components/RelatedContainer/OutfitProducts/OutfitProducts.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import CardList from '../CardList/CardList.jsx';
+import CardList from '../CardList/CardList';
 
 const OutfitProducts = () => {
   // will access the state for products in CART
   // will render the card list for that array
 
   return (
-    <div className="outfitProductsContainer">
+    <section data-testid="outfitProductsContainer">
       <p>under construction</p>
       <CardList />
-    </div>
+    </section>
   );
 };
 

--- a/client/src/Components/RelatedContainer/RelatedContainer.jsx
+++ b/client/src/Components/RelatedContainer/RelatedContainer.jsx
@@ -4,7 +4,7 @@ import OutfitProducts from './OutfitProducts/OutfitProducts.jsx';
 
 const RelatedContainer = () => {
   return (
-    <div>
+    <div className="relatedContainer">
       <RelatedProducts />
 
       <OutfitProducts />

--- a/client/src/Components/RelatedContainer/RelatedContainer.test.js
+++ b/client/src/Components/RelatedContainer/RelatedContainer.test.js
@@ -1,9 +1,16 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import RelatedContainer from './RelatedContainer.jsx';
 
 describe('RelatedContainer', () => {
   test('renders Related Container component', () => {
     render(<RelatedContainer />);
+  });
+
+  test('displays two sets of related products', () => {
+    render(<RelatedContainer />);
+
+    expect(screen.getByTestId('outfitProductsContainer')).toBeTruthy();
+    expect(screen.getByTestId('relatedProductsContainer')).toBeTruthy();
   });
 });

--- a/client/src/Components/RelatedContainer/RelatedProducts/RelatedProducts.jsx
+++ b/client/src/Components/RelatedContainer/RelatedProducts/RelatedProducts.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import CardList from '../CardList/CardList.jsx';
+import CardList from '../CardList/CardList';
 
 const RelatedProducts = () => {
   // will access the state for products in PRODUCTS
   // will render the card list for that array
 
   return (
-    <div className="relatedProductsContainer">
+    <section data-testid="relatedProductsContainer">
       <p>under construction</p>
       <CardList />
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
Write more tests to extend coverage for RelatedContainer.

Just a simple test to look for the two DOM nodes for Related and Outfit sections.

![Screen Shot 2021-09-13 at 10 57 26 AM](https://user-images.githubusercontent.com/60903378/133133224-4f870b53-9f4e-4679-a747-ecdeb1ec9a06.png)
