### PR TITLE
Write useful tests for ProductCard.

### DIFF
--- a/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.test.js
+++ b/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.test.js
@@ -5,6 +5,10 @@ import { ProductsContext } from '../../../../contexts/ProductsContext.jsx';
 import sampleProduct from './sampleProduct';
 
 describe('ProductCard', () => {
+  // TODO:
+  //  - 1.4.1.1.1: conditional render for SALE price
+  //  - 1.4.1.1.4: test rendering for star reviews
+
   let props;
   beforeEach(() => {
     props = { ...sampleProduct };

--- a/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.test.js
+++ b/client/src/Components/RelatedContainer/CardList/ProductCard/ProductCard.test.js
@@ -1,32 +1,79 @@
 import React from 'react';
-import { screen, render } from '../../../../test-utils.jsx';
+import { screen, render, fireEvent } from '../../../../test-utils.jsx';
 import ProductCard from './ProductCard.jsx';
+import { ProductsContext } from '../../../../contexts/ProductsContext.jsx';
 import sampleProduct from './sampleProduct';
 
 describe('ProductCard', () => {
   let props;
-
-  // accepts an action button to display
-
-  // handles logic for hovering for price comparison
-  // handles some logic for clicking action button
-  // handles some logic for changing the page to display this product
-
   beforeEach(() => {
-    // Refresh the props object before each test
     props = { ...sampleProduct };
-  });
-
-  test('renders ProductCard component', () => {
-    render(<ProductCard {...props} />);
   });
 
   test('renders product details from props', () => {
     render(<ProductCard {...props} />);
-
     expect(screen.getByText('Camo Onesie')).toBeInTheDocument();
     expect(screen.getByText('Jackets')).toBeInTheDocument();
     expect(screen.getByText('$140')).toBeInTheDocument();
+  });
+
+  test('renders an image for the product', () => {
+    render(<ProductCard {...props} />);
     expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  test('accepts a button component from props and renders it', () => {
+    const ActionBtn = (
+      <button data-testid="actionBtn">EXAMPLE BUTTON TEXT</button>
+    );
+    render(<ProductCard {...props} ActionBtn={ActionBtn} />);
+
+    expect(screen.getByText('EXAMPLE BUTTON TEXT')).toBeInTheDocument();
+  });
+
+  test('clicking updates the currently display product in context', () => {
+    // Mock the Context function that should be triggered
+    const updateDisplayedProduct = jest.fn();
+    render(
+      <ProductsContext.Provider value={{ updateDisplayedProduct }}>
+        <ProductCard {...props} />
+      </ProductsContext.Provider>,
+    );
+
+    // Click this product card
+    const clickableDetails = screen.getByRole('button');
+    fireEvent.click(clickableDetails);
+
+    expect(updateDisplayedProduct).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking updates the detail page to display THIS product', () => {
+    render(<ProductCard {...props} />);
+    const descText = sampleProduct.description;
+    const clickableDetails = screen.getByRole('button');
+
+    fireEvent.click(clickableDetails);
+
+    // State will update 'asynchronously, THEN we can
+    // verify that the DOM rendered the new value
+    setTimeout(() => {
+      expect(screen.getByText(descText)).toBeInTheDocument();
+    }, 0);
+  });
+
+  test('renders the comparison component on hover', () => {
+    render(<ProductCard {...props} />);
+    fireEvent.mouseOver(screen.getByText(props.name));
+
+    setTimeout(() => {
+      expect(screen.getByRole('figure')).toBeInTheDocument();
+      expect(screen.getByText(props.description)).toBeInTheDocument();
+    }, 0);
+
+    fireEvent.mouseLeave(screen.getByText(props.name));
+
+    setTimeout(() => {
+      expect(screen.getByRole('figure')).not.toBeInTheDocument();
+    }, 0);
   });
 });


### PR DESCRIPTION
#### Created failing tests for the ProductCard component.
Only tests relevant to THIS specific component. Any children with their own logic will have tests in that folder.

![Screen Shot 2021-09-14 at 11 08 22 AM](https://user-images.githubusercontent.com/60903378/133310703-a709e4f2-9ab0-4873-aea5-73f49567ddf7.png)

### 💠  Line 29 Test:
I created a [MOCK context](https://polvara.me/posts/mocking-context-with-react-testing-library) to wrap the component in. I also create a [MOCK function](https://jestjs.io/docs/mock-functions) with a hard-coded name (`updateDisplayedProduct`). After simulating a button click, the component should have called that function stored in the Context hook.

### 💠  Line 54 Test:
When the (clickable part of the) card is clicked, the page should change to display details for that product. The Overview module should now display images, price, description and more for the clicked product. It is re-rendered successfully, we should be able to find the description in the DOM, which wasn't displayed anywhere as a card. If we change the page url, like '/product123' -> click a card -> '/product591', this test wouldn't be relevant anymore.

### 💠  Line 68 Test:
Hovering over a card should make a Comparison component be display. This test will assert that the Comparison component (a html figure tag/role) will be render. The test will hover over the "product name" element, instead of the entire card div.

>  Side note: If you are curious why, it is for two reason. First, the using react-bootstap `<Card data-testid="productCard">` does not work since it transforms it into a DIV to render, and does not pass down all attributes. Second, the ENTIRE card trigger a hover because there needs to be a way to scroll thumbnail images for a future feature.

--- 
### Product Comparison Hover Figure 🐭 
![Product Comparison](https://user-images.githubusercontent.com/60903378/133309867-45dcf5ec-01ac-447b-a929-9c4ac8b8f1bb.png)

