### PR TITLE
import schema for empty stored theme 

### DIFF
--- a/client/src/theme/useTheme.js
+++ b/client/src/theme/useTheme.js
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react"
 import { setToStorage, getFromStorage } from "../utils/storage"
+import themeSchema from "./schema.json"
 import _ from "lodash"
 
 export const useTheme = () => {
   const themes = getFromStorage("all-themes")
-  const [theme, setTheme] = useState(themes.data.light)
+  const [theme, setTheme] = useState(themeSchema.data.light)
   const [themeLoaded, setThemeLoaded] = useState(false)
 
   const setMode = (mode) => {
@@ -14,7 +15,8 @@ export const useTheme = () => {
   }
 
   const getFonts = () => {
-    const allFonts = _.values(_.mapValues(themes.data, "font"))
+    const validThemeObj = themes || themeSchema
+    const allFonts = _.values(_.mapValues(validThemeObj.data, "font"))
     return allFonts
   }
 
@@ -32,8 +34,10 @@ export const useTheme = () => {
 
   useEffect(() => {
     const localTheme = getFromStorage("theme")
-    const newTheme = localTheme ? localTheme : themes.data.light
-    setTheme(newTheme)
+    if (localTheme && localTheme.data) {
+      const newTheme = themes.data.light
+      setTheme(newTheme)
+    }
     setThemeLoaded(true)
   }, [])
 

--- a/client/src/theme/useTheme.js
+++ b/client/src/theme/useTheme.js
@@ -4,8 +4,8 @@ import themeSchema from "./schema.json"
 import _ from "lodash"
 
 export const useTheme = () => {
-  const themes = getFromStorage("all-themes")
-  const [theme, setTheme] = useState(themeSchema.data.light)
+  const themes = getFromStorage("all-themes") || themeSchema
+  const [theme, setTheme] = useState(themes.data.light)
   const [themeLoaded, setThemeLoaded] = useState(false)
 
   const setMode = (mode) => {
@@ -15,8 +15,7 @@ export const useTheme = () => {
   }
 
   const getFonts = () => {
-    const validThemeObj = themes || themeSchema
-    const allFonts = _.values(_.mapValues(validThemeObj.data, "font"))
+    const allFonts = _.values(_.mapValues(themes.data, "font"))
     return allFonts
   }
 


### PR DESCRIPTION
## 🔧 Fix:
When App.jsx loads, it loads the useTheme hook. The useTheme hook will look in localstorage for a `theme` object.
If this object is not present, the App component will fail to load, since it is depending on `theme.data`.

Simply load in the `src/theme/schema.json` as a placeholder, and use THIS object in case none is found in LocalStorage