### PR TITLE
added context constants to providers in ProductsContext, QAContext, R…

### DIFF
--- a/client/src/contexts/ProductsContext.jsx
+++ b/client/src/contexts/ProductsContext.jsx
@@ -72,6 +72,9 @@ export const ProductsProvider = ({ children }) => {
 
   const value = {
     productList,
+    productInfo,
+    styles,
+    relatedProducts,
     fetchProducts,
     fetchProductInfo,
     fetchProductStyles,
@@ -86,6 +89,9 @@ export const ProductsProvider = ({ children }) => {
 const useProducts = () => {
   const {
     productList,
+    productInfo,
+    styles,
+    relatedProducts,
     fetchProducts,
     fetchProductInfo,
     fetchProductStyles,
@@ -94,6 +100,9 @@ const useProducts = () => {
 
   return {
     productList,
+    productInfo,
+    styles,
+    relatedProducts,
     fetchProducts,
     fetchProductInfo,
     fetchProductStyles,

--- a/client/src/contexts/QAContext.jsx
+++ b/client/src/contexts/QAContext.jsx
@@ -139,6 +139,8 @@ export const QAProvider = ({ children }) => {
   }
 
   const value = {
+    questionsList,
+    answersList,
     fetchQuestions,
     fetchAnswers,
     postQuestion,
@@ -154,6 +156,8 @@ export const QAProvider = ({ children }) => {
 
 const useQA = () => {
   const {
+    questionsList,
+    answersList,
     fetchQuestions,
     fetchAnswers,
     postQuestion,
@@ -165,6 +169,8 @@ const useQA = () => {
   } = useContext(QAContext)
 
   return {
+    questionsList,
+    answersList,
     fetchQuestions,
     fetchAnswers,
     postQuestion,

--- a/client/src/contexts/ReviewsContext.jsx
+++ b/client/src/contexts/ReviewsContext.jsx
@@ -108,6 +108,8 @@ export const ReviewsProvider = ({ children }) => {
   }
 
   const value = {
+    reviews,
+    reviewMetadata,
     fetchReviews,
     fetchReviewMetadata,
     addReview,
@@ -120,6 +122,8 @@ export const ReviewsProvider = ({ children }) => {
 
 const useReviews = () => {
   const {
+    reviews,
+    reviewMetadata,
     fetchReviews,
     fetchReviewMetadata,
     addReview,
@@ -128,6 +132,8 @@ const useReviews = () => {
   } = useContext(ReviewsContext)
 
   return {
+    reviews,
+    reviewMetadata,
     fetchReviews,
     fetchReviewMetadata,
     addReview,


### PR DESCRIPTION
I caught a bug where only the methods and not the constants were being included in the context providers of ProductsContext, QAContext, and ReviewsContext. This was blocking `reviews`, etc. from being accessed in components. 