### PR TITLE
Reviews bugfixes & getAverageRating implementation

### DIFF
--- a/client/src/Components/ReviewsContainer/Breakdowns/Breakdowns.jsx
+++ b/client/src/Components/ReviewsContainer/Breakdowns/Breakdowns.jsx
@@ -16,6 +16,7 @@ const Breakdowns = (props) => {
         ct += 1 * reviewMetadata.ratings[rating]
       }
       if (total > 0) {
+        console.log(ct)
         avg = Math.round((total / ct) * 10) / 10
       }
       setAvgRating(avg)
@@ -25,7 +26,7 @@ const Breakdowns = (props) => {
 
   return (
     <section className="breakdowns">
-      {reviewCt > 0 ? (
+      {reviewMetadata.ratings ? (
         <RatingBkdn
           filterReviews={props.filterReviews}
           average={avgRating}

--- a/client/src/Components/ReviewsContainer/Breakdowns/Breakdowns.jsx
+++ b/client/src/Components/ReviewsContainer/Breakdowns/Breakdowns.jsx
@@ -4,34 +4,18 @@ import ProductBkdn from "./ProductBkdn.jsx"
 import useReviews from "../../../contexts/ReviewsContext.jsx"
 
 const Breakdowns = (props) => {
-  const { reviews, reviewMetadata } = useReviews()
+  const { reviews, reviewMetadata, getAverageRating } = useReviews()
   const [avgRating, setAvgRating] = useState(0)
   const [reviewCt, setreviewCt] = useState(0)
 
   useEffect(() => {
-    if (reviews.length > 0) {
-      let [total, ct, avg] = [0, 0, 0]
-      for (let rating in reviewMetadata.ratings) {
-        total += rating * reviewMetadata.ratings[rating]
-        ct += 1 * reviewMetadata.ratings[rating]
-      }
-      if (total > 0) {
-        console.log(ct)
-        avg = Math.round((total / ct) * 10) / 10
-      }
-      setAvgRating(avg)
-      setreviewCt(ct)
-    }
+    setAvgRating(getAverageRating(42366))
   }, [reviewMetadata])
 
   return (
     <section className="breakdowns">
       {avgRating > 0 ? (
-        <RatingBkdn
-          filterReviews={props.filterReviews}
-          average={avgRating}
-          count={reviewCt}
-        />
+        <RatingBkdn filterReviews={props.filterReviews} average={avgRating} />
       ) : null}
       {reviewMetadata.characteristics ? <ProductBkdn /> : null}
     </section>

--- a/client/src/Components/ReviewsContainer/Breakdowns/Breakdowns.jsx
+++ b/client/src/Components/ReviewsContainer/Breakdowns/Breakdowns.jsx
@@ -26,7 +26,7 @@ const Breakdowns = (props) => {
 
   return (
     <section className="breakdowns">
-      {reviewMetadata.ratings ? (
+      {avgRating > 0 ? (
         <RatingBkdn
           filterReviews={props.filterReviews}
           average={avgRating}

--- a/client/src/Components/ReviewsContainer/Breakdowns/RatingBkdn.jsx
+++ b/client/src/Components/ReviewsContainer/Breakdowns/RatingBkdn.jsx
@@ -61,8 +61,8 @@ const RatingBkdn = (props) => {
     <Row>
       <Col>
         {`${
-          props.count > 0
-            ? Math.round((reviewMetadata.recommended.true / props.count) * 100)
+          reviews.length > 0
+            ? Math.round((reviewMetadata.recommended.true / reviews.length) * 100)
             : 0
         }% of reviews recommend this product `}
       </Col>
@@ -74,12 +74,7 @@ const RatingBkdn = (props) => {
       {filters.length > 0 ? <Filters /> : null}
       <Average />
       {[5, 4, 3, 2, 1].map((rating, i) => (
-        <Bar
-          key={i}
-          rating={rating}
-          count={props.count}
-          filterReviews={props.filterReviews}
-        />
+        <Bar key={i} rating={rating} filterReviews={props.filterReviews} />
       ))}
       <Recs />
     </Container>

--- a/client/src/Components/ReviewsContainer/Breakdowns/RatingBkdn.jsx
+++ b/client/src/Components/ReviewsContainer/Breakdowns/RatingBkdn.jsx
@@ -28,7 +28,7 @@ const RatingBkdn = (props) => {
       <Col xs={12} md={6}>
         <ProgressBar
           variant="success"
-          max={props.count}
+          max={reviews.length}
           now={reviewMetadata.ratings[props.rating]}
         ></ProgressBar>
       </Col>

--- a/client/src/Components/ReviewsContainer/Breakdowns/RatingBkdn.jsx
+++ b/client/src/Components/ReviewsContainer/Breakdowns/RatingBkdn.jsx
@@ -74,7 +74,12 @@ const RatingBkdn = (props) => {
       {filters.length > 0 ? <Filters /> : null}
       <Average />
       {[5, 4, 3, 2, 1].map((rating, i) => (
-        <Bar key={i} rating={Math.abs(i - 5)} filterReviews={props.filterReviews} />
+        <Bar
+          key={i}
+          rating={rating}
+          count={props.count}
+          filterReviews={props.filterReviews}
+        />
       ))}
       <Recs />
     </Container>

--- a/client/src/Components/ReviewsContainer/ReviewsContainer.jsx
+++ b/client/src/Components/ReviewsContainer/ReviewsContainer.jsx
@@ -11,7 +11,7 @@ const ReviewsContainer = () => {
   const [product_id, setProduct_id] = useState(42366)
 
   useEffect(() => {
-    fetchReviews(1, 100, sort, product_id, filters)
+    fetchReviews(1, 100, sort, product_id, filters, (data) => {})
   }, [sort, product_id, filters])
 
   useEffect(() => {

--- a/client/src/contexts/ReviewsContext.jsx
+++ b/client/src/contexts/ReviewsContext.jsx
@@ -40,13 +40,14 @@ export const ReviewsProvider = ({ children }) => {
     ],
   })
 
-  const fetchReviews = (page, count, sort, product_id) => {
+  const fetchReviews = (page, count, sort, product_id, filters, callback) => {
     const fetchDetails = {
       page,
       count,
       sort,
       product_id,
       filters,
+      callback,
     }
 
     axios({
@@ -55,7 +56,6 @@ export const ReviewsProvider = ({ children }) => {
       params: fetchDetails,
     })
       .then((response) => {
-        setReviews(response.data.results)
         filters.length === 0
           ? setReviews(response.data.results)
           : setReviews(
@@ -69,6 +69,7 @@ export const ReviewsProvider = ({ children }) => {
               }, [])
             )
         setFilters(filters)
+        callback(response.data.results)
       })
       .catch((err) => {
         console.log("Server failed to fetch all reviews")
@@ -134,6 +135,24 @@ export const ReviewsProvider = ({ children }) => {
       })
   }
 
+  const getAverageRating = (product_id) => {
+    let avg = 0
+
+    const setAvg = (reviews) => {
+      let sum = reviews.reduce((sum, { rating }) => (sum += rating), 0)
+      avg = Math.round((sum / reviews.length) * 10) / 10
+    }
+
+    if (!reviews) {
+      fetchReviews(1, 100, "relevant", product_id, (reviews) => setAvg(reviews))
+    } else if (reviews.length > 0) {
+      setAvg(reviews)
+    } else {
+      return 0
+    }
+    return avg
+  }
+
   const value = {
     reviews,
     reviewMetadata,
@@ -145,6 +164,7 @@ export const ReviewsProvider = ({ children }) => {
     markReviewHelpful,
     reportReview,
     setFilters,
+    getAverageRating,
   }
 
   return <ReviewsContext.Provider value={value}>{children}</ReviewsContext.Provider>
@@ -162,6 +182,7 @@ const useReviews = () => {
     markReviewHelpful,
     reportReview,
     setFilters,
+    getAverageRating,
   } = useContext(ReviewsContext)
 
   return {
@@ -175,6 +196,7 @@ const useReviews = () => {
     markReviewHelpful,
     reportReview,
     setFilters,
+    getAverageRating,
   }
 }
 

--- a/client/src/contexts/ReviewsContext.jsx
+++ b/client/src/contexts/ReviewsContext.jsx
@@ -46,6 +46,7 @@ export const ReviewsProvider = ({ children }) => {
       count,
       sort,
       product_id,
+      filters,
     }
 
     axios({
@@ -55,6 +56,19 @@ export const ReviewsProvider = ({ children }) => {
     })
       .then((response) => {
         setReviews(response.data.results)
+        filters.length === 0
+          ? setReviews(response.data.results)
+          : setReviews(
+              response.data.results.reduce((filtered, current) => {
+                filters.forEach((option) => {
+                  if (current.rating === option) {
+                    filtered.push(current)
+                  }
+                })
+                return filtered
+              }, [])
+            )
+        setFilters(filters)
       })
       .catch((err) => {
         console.log("Server failed to fetch all reviews")
@@ -130,6 +144,7 @@ export const ReviewsProvider = ({ children }) => {
     addReview,
     markReviewHelpful,
     reportReview,
+    setFilters,
   }
 
   return <ReviewsContext.Provider value={value}>{children}</ReviewsContext.Provider>
@@ -146,6 +161,7 @@ const useReviews = () => {
     addReview,
     markReviewHelpful,
     reportReview,
+    setFilters,
   } = useContext(ReviewsContext)
 
   return {
@@ -158,6 +174,7 @@ const useReviews = () => {
     addReview,
     markReviewHelpful,
     reportReview,
+    setFilters,
   }
 }
 


### PR DESCRIPTION
The **# stars** links now properly filter the reviews, and the bars next to them reflect the counts more accurately -- my changes from the 1.2.4 PR had gotten lost, but I was able to find them in the PR history and restore them.

Also, the `getAverageRating` method has been implemented in `ReviewsContext`! The method
- takes one parameter (`product_id` of the displayed product),
- checks for fetched reviews,
- & accounts for products with 0 reviews (returns 0). 

I'm currently using it in the Reviews module, and it's working as expected. 